### PR TITLE
OMP is less memory intensive + notebook improvements

### DIFF
--- a/README.md
+++ b/README.md
@@ -33,9 +33,9 @@
     * [Viewing images](https://reillytilbury.github.io/coppafish/diagnostics/#viewing-images)
 * [Advanced Usage](https://reillytilbury.github.io/coppafish/advanced_usage/)
 * [Troubleshoot](https://reillytilbury.github.io/coppafish/troubleshoot/)
+* [Algorithm](https://reillytilbury.github.io/coppafish/algorithm/)
 * [Contributing](https://reillytilbury.github.io/coppafish/contributing/)
 * [Glossary](https://reillytilbury.github.io/coppafish/glossary/)
-* [Call Spots](https://reillytilbury.github.io/coppafish/call_spots/)
 ![](https://github.com/jduffield65/coppafish/blob/main/docs/images/readme_viewer.png?raw=true)
 
 For more information on coppafish's method, please see the [documentation](https://jduffield65.github.io/coppafish/) 

--- a/changelog.txt
+++ b/changelog.txt
@@ -11,7 +11,8 @@
     been moved from the `filter` section to the `extract` section.
  * OMP: Pixel colours are not background fitted before being run through OMP. OMP stop iterating on a pixel if the 
     background gets fitted anyway and the background fitting may be removing important colour information.
- * The notebook has been refactored. It is now faster at saving, can save zarr arrays and has write protections.
+ * The notebook has been refactored. It is now faster at saving, can save zarr arrays/groups, and has write protections.
+ * OMP: Less memory intensive by saving each tile's results separately. The results are also now compressed.
  * Extract: Default z_plane_mean_warning 200 -> 125.
  * Register: Moved bg_scale from filter page -> register page.
  * Viewer refactor: Viewer is now much faster and less laggy, due to the removal of a transparent copy of the spots, and

--- a/changelog.txt
+++ b/changelog.txt
@@ -12,7 +12,7 @@
  * OMP: Pixel colours are not background fitted before being run through OMP. OMP stop iterating on a pixel if the 
     background gets fitted anyway and the background fitting may be removing important colour information.
  * The notebook has been refactored. It is now faster at saving, can save zarr arrays/groups, and has write protections.
- * OMP: Less memory intensive by saving each tile's results separately. The results are also now compressed.
+ * OMP: Less memory intensive by saving each tile's results separately. Also, the results are compressed.
  * Extract: Default z_plane_mean_warning 200 -> 125.
  * Register: Moved bg_scale from filter page -> register page.
  * Viewer refactor: Viewer is now much faster and less laggy, due to the removal of a transparent copy of the spots, and

--- a/coppafish/omp/base.py
+++ b/coppafish/omp/base.py
@@ -1,0 +1,83 @@
+from typing import Tuple
+import numpy as np
+import numpy.typing as npt
+
+from ..setup import NotebookPage
+
+
+def get_all_scores(
+    nbp_basic: NotebookPage, nbp_omp: NotebookPage
+) -> Tuple[npt.NDArray[np.float16], npt.NDArray[np.int16]]:
+    """
+    Get gene scores for every tile, concatenated together.
+
+    Args:
+        - nbp_basic (notebook page): `basic_info` notebook page.
+        - nbp_omp (notebook page): `omp` notebook page.
+
+    Returns:
+        - (`(n_spots) ndarray[float16]`) all_scores: all gene scores.
+        - (`(n_spots) ndarray[int16]`) all_tiles: the tile for each spot.
+    """
+    assert type(nbp_basic) is NotebookPage
+    assert type(nbp_omp) is NotebookPage
+
+    all_scores = np.zeros(0, np.float16)
+    all_tiles = np.zeros(0, np.int16)
+    for t in nbp_basic.use_tiles:
+        t_scores: np.ndarray = nbp_omp.results[f"tile_{t}/scores"][:]
+        all_scores = np.append(all_scores, t_scores, 0)
+        all_tiles = np.append(all_tiles, np.full(t_scores.size, t, np.int16))
+    return all_scores, all_tiles
+
+
+def get_all_gene_no(
+    nbp_basic: NotebookPage, nbp_omp: NotebookPage
+) -> Tuple[npt.NDArray[np.int16], npt.NDArray[np.int16]]:
+    """
+    Get gene numbers for every tile, concatenated together.
+
+    Args:
+        - nbp_basic (notebook page): `basic_info` notebook page.
+        - nbp_omp (notebook page): `omp` notebook page.
+
+    Returns:
+        - (`(n_spots) ndarray[int16]`) all_gene_no: all gene numbers.
+        - (`(n_spots) ndarray[int16]`) all_tiles: the tile for each spot.
+    """
+    assert type(nbp_basic) is NotebookPage
+    assert type(nbp_omp) is NotebookPage
+
+    all_gene_no = np.zeros(0, np.int16)
+    all_tiles = np.zeros(0, np.int16)
+    for t in nbp_basic.use_tiles:
+        t_gene_no: np.ndarray = nbp_omp.results[f"tile_{t}/gene_no"][:]
+        all_gene_no = np.append(all_gene_no, t_gene_no, 0)
+        all_tiles = np.append(all_tiles, np.full(t_gene_no.size, t, np.int16))
+    return all_gene_no, all_tiles
+
+
+def get_all_local_yxz(
+    nbp_basic: NotebookPage, nbp_omp: NotebookPage
+) -> Tuple[npt.NDArray[np.int16], npt.NDArray[np.int16]]:
+    """
+    Get spot local positions for every tile, concatenated together.
+
+    Args:
+        - nbp_basic (notebook page): `basic_info` notebook page.
+        - nbp_omp (notebook page): `omp` notebook page.
+
+    Returns:
+        - (`(n_spots) ndarray[int16]`) all_local_yxz: all gene local positions.
+        - (`(n_spots) ndarray[int16]`) all_tiles: the tile for each spot.
+    """
+    assert type(nbp_basic) is NotebookPage
+    assert type(nbp_omp) is NotebookPage
+
+    all_local_yxz = np.zeros((0, 3), np.int16)
+    all_tiles = np.zeros(0, np.int16)
+    for t in nbp_basic.use_tiles:
+        t_local_yxz: np.ndarray = nbp_omp.results[f"tile_{t}/local_yxz"][:]
+        all_local_yxz = np.append(all_local_yxz, t_local_yxz, 0)
+        all_tiles = np.append(all_tiles, np.full(t_local_yxz.size, t, np.int16))
+    return all_local_yxz, all_tiles

--- a/coppafish/omp/base.py
+++ b/coppafish/omp/base.py
@@ -81,3 +81,29 @@ def get_all_local_yxz(
         all_local_yxz = np.append(all_local_yxz, t_local_yxz, 0)
         all_tiles = np.append(all_tiles, np.full(t_local_yxz.size, t, np.int16))
     return all_local_yxz, all_tiles
+
+
+def get_all_colours(
+    nbp_basic: NotebookPage, nbp_omp: NotebookPage
+) -> Tuple[npt.NDArray[np.float16], npt.NDArray[np.int16]]:
+    """
+    Get spot local positions for every tile, concatenated together.
+
+    Args:
+        - nbp_basic (notebook page): `basic_info` notebook page.
+        - nbp_omp (notebook page): `omp` notebook page.
+
+    Returns:
+        - (`(n_spots) ndarray[int16]`) all_colours: all spot colours.
+        - (`(n_spots) ndarray[int16]`) all_tiles: the tile for each spot.
+    """
+    assert type(nbp_basic) is NotebookPage
+    assert type(nbp_omp) is NotebookPage
+
+    all_colours = np.zeros((0, 3), np.float16)
+    all_tiles = np.zeros(0, np.int16)
+    for t in nbp_basic.use_tiles:
+        t_colours: np.ndarray = nbp_omp.results[f"tile_{t}/colours"][:]
+        all_colours = np.append(all_colours, t_colours, 0)
+        all_tiles = np.append(all_tiles, np.full(t_colours.size, t, np.int16))
+    return all_colours, all_tiles

--- a/coppafish/pipeline/basic_info.py
+++ b/coppafish/pipeline/basic_info.py
@@ -1,10 +1,11 @@
-import os
 import json
+import os
+
 import numpy as np
 
-from ..setup import NotebookPage
-from .. import utils, setup
+from .. import setup, utils
 from .. import log
+from ..setup import NotebookPage
 
 
 def set_basic_info(config_file: dict, config_basic: dict, n_rounds: int = 7) -> NotebookPage:
@@ -290,18 +291,19 @@ def set_basic_info_new(config: dict) -> NotebookPage:
     Returns:
         - `NotebookPage[basic_info]` - Page contains information that is used at all stages of the pipeline.
     """
-    # Initialize Notebook
-    nbp = NotebookPage("basic_info")
+    # Break the page contents up into 2 types, contents that must be read in from the config and those that can
+    # be computed from the metadata.
+    config_file: dict = config["file_names"]
+    config_basic: dict = config["basic_info"]
 
-    # Now break the page contents up into 2 types, contents that must be read in from the config and those that can
-    # be computed from the metadata
-    config_file = config["file_names"]
-    config_basic = config["basic_info"]
+    # Initialize Notebook
+    associated_configs = {"basic_info": config_basic, "file_names": config_file}
+    nbp = NotebookPage("basic_info", associated_configs)
 
     # Stage 1: Compute metadata. This is done slightly differently in the 3 cases of different raw extensions
     raw_extension = utils.nd2.get_raw_extension(config_file["input_dir"])
     all_files = []
-    for root, directories, filenames in os.walk(config_file["input_dir"]):
+    for root, _, filenames in os.walk(config_file["input_dir"]):
         for filename in filenames:
             all_files.append(os.path.join(root, filename))
     all_files.sort()

--- a/coppafish/pipeline/basic_info.py
+++ b/coppafish/pipeline/basic_info.py
@@ -416,7 +416,7 @@ def set_basic_info_new(config: dict) -> NotebookPage:
 
     if nbp.use_dyes is None:
         del nbp.use_dyes
-        nbp.use_dyes = utils.base.to_deep_tuple(np.arange(len(nbp.dye_names)).tolist())
+        nbp.use_dyes = utils.base.deep_convert(np.arange(len(nbp.dye_names)).tolist())
         nbp.n_dyes = len(nbp.use_dyes)
 
     # If preseq round is a file, set pre_seq_round to True, else False and raise warning that pre_seq_round is not a

--- a/coppafish/pipeline/call_reference_spots.py
+++ b/coppafish/pipeline/call_reference_spots.py
@@ -1,4 +1,5 @@
 import itertools
+from typing import Tuple
 
 import matplotlib.pyplot as plt
 import numpy as np
@@ -388,7 +389,7 @@ def view_scale_factors(
 
 def call_reference_spots(
     config: dict, nbp_ref_spots: NotebookPage, nbp_file: NotebookPage, nbp_basic: NotebookPage
-) -> [NotebookPage, NotebookPage]:
+) -> Tuple[NotebookPage, NotebookPage]:
     """
     Function to do gene assignments to reference spots. In doing so we compute some important parameters for the
     downstream analysis.
@@ -417,7 +418,7 @@ def call_reference_spots(
         nbp_ref_spots: NotebookPage
             The reference spots notebook page.
     """
-    log.debug("Call spots started")
+    log.debug("Call spots started", {"call_spots": config})
     nbp = NotebookPage("call_spots")
 
     # load in frequently used variables

--- a/coppafish/pipeline/call_reference_spots.py
+++ b/coppafish/pipeline/call_reference_spots.py
@@ -418,8 +418,8 @@ def call_reference_spots(
         nbp_ref_spots: NotebookPage
             The reference spots notebook page.
     """
-    log.debug("Call spots started", {"call_spots": config})
-    nbp = NotebookPage("call_spots")
+    log.debug("Call spots started")
+    nbp = NotebookPage("call_spots", {"call_spots": config})
 
     # load in frequently used variables
     spot_colours = nbp_ref_spots.colours.astype(float)

--- a/coppafish/pipeline/extract_run.py
+++ b/coppafish/pipeline/extract_run.py
@@ -34,7 +34,7 @@ def run_extract(
             NotImplementedError(f"coppafish 2d is not in a stable state, please contact a dev to add this. Sorry! ;(")
         )
 
-    nbp = NotebookPage("extract")
+    nbp = NotebookPage("extract", {"extract": config})
     nbp.file_type = config["file_type"]
     nbp.num_rotations = config["num_rotations"]
 

--- a/coppafish/pipeline/filter_run.py
+++ b/coppafish/pipeline/filter_run.py
@@ -42,8 +42,8 @@ def run_filter(
     if not nbp_basic.is_3d:
         NotImplementedError(f"2d coppafish is not stable, very sorry! :9")
 
-    nbp = NotebookPage("filter")
-    nbp_debug = NotebookPage("filter_debug")
+    nbp = NotebookPage("filter", {"filter": config})
+    nbp_debug = NotebookPage("filter_debug", {"filter": config})
 
     log.debug("Filter started")
     start_time = time.time()

--- a/coppafish/pipeline/find_spots.py
+++ b/coppafish/pipeline/find_spots.py
@@ -43,7 +43,7 @@ def find_spots(
     use_tiles, use_rounds, use_channels = nbp_basic.use_tiles, nbp_basic.use_rounds, nbp_basic.use_channels
 
     # Phase 0: Initialisation
-    nbp = NotebookPage("find_spots")
+    nbp = NotebookPage("find_spots", {"find_spots": config})
     if nbp_basic.is_3d is False:
         # set z details to None if using 2d pipeline
         config["radius_z"] = None

--- a/coppafish/pipeline/omp_torch.py
+++ b/coppafish/pipeline/omp_torch.py
@@ -59,7 +59,7 @@ def run_omp(
     log.debug(f"{torch.cuda.is_available()=}")
     log.debug(f"{config['force_cpu']=}")
 
-    nbp = NotebookPage("omp")
+    nbp = NotebookPage("omp", {"omp": config})
 
     # We want exact, reproducible results.
     torch.backends.cudnn.deterministic = True

--- a/coppafish/pipeline/register.py
+++ b/coppafish/pipeline/register.py
@@ -441,7 +441,7 @@ def register(
                 im_r = im_r[bright]
                 bg_scale[t, r, c] = np.median(im_r) / np.median(im_pre)
 
-        bg_scale = utils.base.to_deep_tuple(bg_scale.tolist())
+        bg_scale = utils.base.deep_convert(bg_scale.tolist())
         log.debug("Compute background scale factors complete")
     # Now add the bg_scale to the nbp_filter page. To do this we need to delete the bg_scale attribute.
     nbp.bg_scale = bg_scale

--- a/coppafish/pipeline/register.py
+++ b/coppafish/pipeline/register.py
@@ -56,8 +56,8 @@ def register(
     # Part 0: Initialisation
     # Initialise frequently used variables
     log.debug("Register started")
-    nbp = NotebookPage("register")
-    nbp_debug = NotebookPage("register_debug")
+    nbp = NotebookPage("register", {"register": config})
+    nbp_debug = NotebookPage("register_debug", {"register": config})
     use_tiles, use_rounds, use_channels = (
         list(nbp_basic.use_tiles),
         list(nbp_basic.use_rounds),

--- a/coppafish/pipeline/stitch.py
+++ b/coppafish/pipeline/stitch.py
@@ -23,7 +23,7 @@ def stitch(config: dict, nbp_basic: NotebookPage, nbp_file: NotebookPage, nbp_ex
         new `stitch` notebook page.
     """
     log.debug("Stitch started")
-    nbp = NotebookPage("stitch")
+    nbp = NotebookPage("stitch", {"stitch": config})
 
     # initialize the variables
     overlap = config["expected_overlap"]

--- a/coppafish/plot/omp/coefs.py
+++ b/coppafish/plot/omp/coefs.py
@@ -1,5 +1,4 @@
 import os
-import math as maths
 from typing import Tuple
 
 import matplotlib as mpl
@@ -11,6 +10,7 @@ import torch
 from ... import spot_colors
 from ...call_spots import background_pytorch
 from ...omp import coefs_torch, scores_torch
+from ...omp import base as omp_base
 from ...setup import Notebook
 
 
@@ -19,8 +19,9 @@ def get_spot_position_and_tile(nb: Notebook, spot_no: int, method: str) -> Tuple
         local_yxz = nb.ref_spots.local_yxz[spot_no]
         tile = nb.ref_spots.tile[spot_no]
     elif method == "omp":
-        local_yxz = nb.omp.local_yxz[spot_no]
-        tile = nb.omp.tile[spot_no]
+        all_local_yxz, all_tile = omp_base.get_all_local_yxz(nb.basic_info, nb.omp)
+        local_yxz = all_local_yxz[spot_no]
+        tile = all_tile[spot_no].item()
     else:
         raise ValueError(f"Unknown gene calling method: {method}")
     return local_yxz, int(tile)

--- a/coppafish/plot/results_viewer/base.py
+++ b/coppafish/plot/results_viewer/base.py
@@ -17,10 +17,17 @@ import tifffile
 
 from . import legend
 from .. import call_spots as call_spots_plot
+from ...omp import base as omp_base
 from ...setup import Notebook
-from ..call_spots import gene_counts, view_bled_codes, view_bleed_matrix, view_codes, view_intensity, view_spot
+from ..call_spots import gene_counts, view_bled_codes, view_bleed_matrix, view_codes
+from ..call_spots import view_intensity, view_spot
 from ..call_spots_new import BGNormViewer, GEViewer, ViewAllGeneScores
-from ..omp import histogram_score, ViewOMPImage, ViewOMPPixelCoefficients, ViewOMPPixelColours
+from ..omp import (
+    ViewOMPImage,
+    ViewOMPPixelCoefficients,
+    ViewOMPPixelColours,
+    histogram_score,
+)
 from .hotkeys import KeyBinds, ViewHotkeys
 
 try:
@@ -561,13 +568,13 @@ class Viewer:
         gene_no = [nb.ref_spots.dot_product_gene_no, np.argmax(nb.ref_spots.gene_probabilities, axis=1)]
         intensity = [nb.ref_spots.intensity, nb.ref_spots.intensity]
         if nb.has_page("omp"):
-            score.append(nb.omp.scores)
-            gene_no.append(nb.omp.gene_no)
-            omp_colours = nb.omp.colours.copy()
-            omp_colours_float = omp_colours * colour_norm_factor[tile[-1]]
+            score.append(omp_base.get_all_scores(nb.basic_info, nb.omp)[0])
+            gene_no.append(omp_base.get_all_gene_no(nb.basic_info, nb.omp)[0])
+            omp_colours, omp_tiles = omp_base.get_all_colours(nb.basic_info, nb.omp)
+            omp_colours_float = omp_colours * colour_norm_factor[omp_tiles]
             intensity_omp = np.median(np.max(omp_colours_float, axis=-1), axis=-1)
             intensity.append(intensity_omp)
-            colours.append(nb.omp.colours)
+            colours.append(omp_colours)
 
         # add all spots of shown genes to the napari viewer. If a gene is not shown, the spots will be disregarded.
         visible_genes = np.where([g.active for g in self.genes])[0]

--- a/coppafish/robominnie/robominnie.py
+++ b/coppafish/robominnie/robominnie.py
@@ -19,6 +19,7 @@ import pandas
 import scipy.stats
 from tqdm import tqdm
 
+from ..omp import base as omp_base
 from .. import utils
 from ..pipeline import run
 
@@ -1062,13 +1063,12 @@ class RoboMinnie:
             )
 
         assert nb.has_page("omp"), f"OMP not found in notebook at {config_filepath}"
-        # Keep the OMP spot intensities, assigned gene, assigned tile number and the spot positions in the class
-        # instance
-        self.omp_spot_intensities = np.ones_like(nb.omp.gene_no)
-        self.omp_spot_scores = nb.omp.scores
-        self.omp_gene_numbers = nb.omp.gene_no
-        self.omp_tile_number = nb.omp.tile
-        self.omp_spot_local_positions = nb.omp.local_yxz  # yxz position of each gene found
+        # Keep the OMP spot intensities, assigned gene, assigned tile number and the spot positions in the robominnie
+        # class
+        self.omp_spot_scores = omp_base.get_all_scores(nb.basic_info, nb.omp)[0]
+        self.omp_spot_intensities = np.ones_like(self.omp_spot_scores, np.float16)
+        self.omp_gene_numbers, self.omp_tile_number = omp_base.get_all_gene_no(nb.basic_info, nb.omp)
+        self.omp_spot_local_positions = omp_base.get_all_local_yxz(nb.basic_info, nb.omp)[0]
         assert (
             self.omp_gene_numbers.shape[0] == self.omp_spot_local_positions.shape[0]
         ), "Mismatch in spot count in omp.gene_numbers and omp.local_positions"

--- a/coppafish/setup/file_names.py
+++ b/coppafish/setup/file_names.py
@@ -26,7 +26,7 @@ def get_file_names(nb: Notebook):
         nb: *Notebook* containing at least the `basic_info` page.
     """
     config = setup.config.get_config(nb.config_path)["file_names"]
-    nbp = NotebookPage("file_names")
+    nbp = NotebookPage("file_names", {"file_names": config})
     # Copy some variables that are in config to page.
     nbp.input_dir = config["input_dir"]
     nbp.output_dir = config["output_dir"]

--- a/coppafish/setup/file_names.py
+++ b/coppafish/setup/file_names.py
@@ -151,6 +151,6 @@ def get_file_names(nb: Notebook):
                 setup.config.get_config(nb.config_path)["extract"]["file_type"],
             )
 
-    nbp.tile = utils.base.to_deep_tuple(tile_names.tolist())
-    nbp.tile_unfiltered = utils.base.to_deep_tuple(tile_names_unfiltered.tolist())
+    nbp.tile = utils.base.deep_convert(tile_names.tolist())
+    nbp.tile_unfiltered = utils.base.deep_convert(tile_names_unfiltered.tolist())
     return nbp

--- a/coppafish/setup/notebook_page.py
+++ b/coppafish/setup/notebook_page.py
@@ -616,31 +616,16 @@ class NotebookPage:
                 + ""
                 + "0 means unsure of sign.",
             ],
-            "local_yxz": [
-                "ndarray[int16]",
-                "Numpy array [n_spots, 3]"
-                + "`local_yxz[s]` are the $yxz$ coordinates of spot $s$ found on `tile[s]`, `ref_round`, `ref_channel`."
-                + "To get `global_yxz`, add `nb.stitch.tile_origin[tile[s]]`.",
-            ],
-            "scores": [
-                "ndarray[float16]",
-                "Numpy array [n_spots]"
-                + "For each spot `s`, specified by position `local_yxz[s]` at tile `tile[s]` with gene read `gene_no[s]`, "
-                + "has gene read score of `scores[s]`. Each score is between 0 and 1.",
-            ],
-            "tile": [
-                "ndarray[int16]",
-                "Numpy array [n_spots]" + "Tile each spot was found on.",
-            ],
-            "gene_no": [
-                "ndarray[int16]",
-                "Numpy array [n_spots]" + "`gene_no[s]` is the index of the gene assigned to spot $s$.",
-            ],
-            "colours": [
-                "ndarray[float16]",
-                "Numpy `(n_spots x len(use_rounds) x len(use_channels))`. "
-                + "Each spot's registered intensity in every sequencing round/channel. "
-                + "No postprocessing is applied to the colours.",
+            "results": [
+                "zgroup",
+                "A zarr group containing all OMP spots. Each tile's results are separated into subgroups. "
+                + "For example, you can access tile 0's subgroup by doing `nb.omp.results['tile_0']`. Each tile "
+                + "subgroup contains 4 zarr arrays: local_yxz, scores, gene_no, and colours. Each has dtype int16, "
+                + "float16, int16, and float16 respectively. Each has shape (n_spots, 3), (n_spots), (n_spots), "
+                + "(n_spots) respectively. "
+                + "To gather tile 0's spot's local_yxz's into memory, do `nb.omp.results['tile_0/local_yxz'][:]`. "
+                + "The local_yxz positions are relative to the tile. To convert these to global spot positions "
+                + "requires adding the tile_origin from the 'stitch' page.",
             ],
         },
         "thresholds": {

--- a/coppafish/setup/settings.default.ini
+++ b/coppafish/setup/settings.default.ini
@@ -421,7 +421,7 @@ radius_xy = 3
 radius_z = 2
 
 ; spot_shape specifies the neighbourhood about each spot in which we count coefficients which contribute to score.
-spot_shape = 7, 7, 5
+spot_shape = 9, 9, 5
 
 ; If the number of isolated spots goes above this value, then no more spots are used to compute the OMP spot/mean spot.
 spot_shape_max_spots = 50_000
@@ -436,7 +436,7 @@ shape_isolation_distance_yx = 10
 shape_isolation_distance_z = 
 
 ; Spots are used to compute the OMP spot shape when they have a coefficient local maxima greater than this value.
-shape_coefficient_threshold = 0.4
+shape_coefficient_threshold = 0.8
 
 ; If the mean absolute coefficient sign is less than this in a region near a spot,
 ; the expected coefficient in `spot` is set to 0.

--- a/coppafish/setup/test/test_setup_notebook.py
+++ b/coppafish/setup/test/test_setup_notebook.py
@@ -6,6 +6,7 @@ import tempfile
 import numpy as np
 import zarr
 
+from coppafish import utils
 from coppafish.setup.notebook import Notebook
 from coppafish.setup.notebook_page import NotebookPage
 
@@ -46,9 +47,9 @@ def test_notebook_creation() -> None:
         assert np.allclose(nb.debug.b, b)
         assert np.allclose(nb.debug.c, c)
         assert np.allclose(nb.debug.d, d)
-        assert type(nb.debug.d) is tuple
-        assert nb.debug.e == e
-        assert type(nb.debug.e) is tuple
+        assert type(nb.debug.d) is list
+        assert nb.debug.e == utils.base.deep_convert(e, list)
+        assert type(nb.debug.e) is list
         assert np.allclose(nb.debug.f, f)
         assert nb.debug.g is g
         assert np.allclose(nb.debug.h, h)
@@ -79,6 +80,8 @@ def test_notebook_creation() -> None:
     nb_page.c = c
     try:
         nb_page.d = (5, "4", True)
+        nb_page.d = (5, "4")
+        nb_page.d = (5, 0.5)
         assert False, "Should not be able to set a tuple[int] type like this"
     except TypeError:
         pass

--- a/coppafish/setup/test/test_setup_notebook.py
+++ b/coppafish/setup/test/test_setup_notebook.py
@@ -1,6 +1,7 @@
 import os
 from pathlib import PurePath
 import shutil
+import tempfile
 
 import numpy as np
 import zarr
@@ -57,10 +58,16 @@ def test_notebook_creation() -> None:
         assert np.allclose(nb.debug.l, l)
         assert (nb.debug.m == m).all()
         assert np.allclose(nb.debug.n, n)
-        zarr_path = os.path.abspath(nb.debug.o.store.path)
-        assert os.path.isdir(zarr_path)
-        assert len(os.listdir(zarr_path)) > 0
-        assert PurePath(nb_path) in PurePath(zarr_path).parents
+        zarray_path = os.path.abspath(nb.debug.o.store.path)
+        assert os.path.isdir(zarray_path)
+        assert len(os.listdir(zarray_path)) > 0
+        assert PurePath(nb_path) in PurePath(zarray_path).parents
+        zgroup_path = os.path.abspath(nb.debug.p.store.path)
+        assert os.path.isdir(zgroup_path)
+        assert len(os.listdir(zgroup_path)) > 0
+        assert type(nb.debug.p["subgroup"]) is zarr.Group
+        assert type(nb.debug.p["subarray.zarr"]) is zarr.Array
+        assert nb.debug.p["subarray.zarr"].shape == (10, 5)
 
     nb_page.a = a
     try:
@@ -120,20 +127,32 @@ def test_notebook_creation() -> None:
     except ValueError:
         pass
 
-    zarr_path = os.path.join(os.getcwd(), ".test_array.zarr")
+    temp_zarr = tempfile.TemporaryDirectory()
     array_saved = np.zeros((4, 8), dtype=np.float32)
     zarr_array_temp = zarr.open_array(
-        store=zarr_path, shape=array_saved.shape, dtype="|f4", zarr_version=2, chunks=(2, 4), mode="w"
+        store=temp_zarr.name, shape=array_saved.shape, dtype="|f4", zarr_version=2, chunks=(2, 4), mode="w"
     )
     zarr_array_temp[:] = array_saved.copy()
 
-    assert nb_page.get_unset_variables() == ("o",)
+    assert nb_page.get_unset_variables() == ("o", "p")
 
     nb_page.o = zarr_array_temp
     del zarr_array_temp
 
-    assert len(nb_page.get_unset_variables()) == 0
+    assert len(nb_page.get_unset_variables()) == 1
     assert nb_page.name == "debug"
+
+    try:
+        nb += nb_page
+        assert False, f"Shoul not be able to add an unfinished page to the notebook"
+    except ValueError:
+        pass
+
+    temp_zgroup = tempfile.TemporaryDirectory()
+    group = zarr.group(store=temp_zgroup.name, zarr_version=2)
+    group.create_dataset("subarray.zarr", shape=(10, 5), dtype=np.int16)
+    group.create_group("subgroup")
+    nb_page.p = group
 
     nb += nb_page
 
@@ -177,6 +196,10 @@ def test_notebook_creation() -> None:
 
     # Delete the temporary notebook once done testing.
     shutil.rmtree(nb_path)
+
+    # Clean any temporary files/directories.
+    temp_zarr.cleanup()
+    temp_zgroup.cleanup()
 
 
 if __name__ == "__main__":

--- a/coppafish/setup/test/test_setup_notebook.py
+++ b/coppafish/setup/test/test_setup_notebook.py
@@ -18,7 +18,7 @@ def test_notebook_creation() -> None:
     if os.path.isdir(nb_path):
         shutil.rmtree(nb_path)
     config_path = os.path.abspath("dslkhgdsjlgh")
-    nb = Notebook(nb_path, config_path, True)
+    nb = Notebook(nb_path, config_path)
 
     assert nb.has_page("debug") == False
     assert nb.config_path == config_path
@@ -203,7 +203,3 @@ def test_notebook_creation() -> None:
     # Clean any temporary files/directories.
     temp_zarr.cleanup()
     temp_zgroup.cleanup()
-
-
-if __name__ == "__main__":
-    test_notebook_creation()

--- a/coppafish/spot_colors/base.py
+++ b/coppafish/spot_colors/base.py
@@ -102,7 +102,7 @@ def get_spot_colours_new(
     assert type(tile) is int
     assert type(round) is int
     if channels is None:
-        channels = nbp_basic.use_channels
+        channels = tuple(nbp_basic.use_channels)
     if type(channels) is int:
         channels = (channels,)
     assert type(channels) is tuple

--- a/coppafish/utils/raw.py
+++ b/coppafish/utils/raw.py
@@ -133,9 +133,9 @@ def load_dask(nbp_file: NotebookPage, nbp_basic: NotebookPage, r: int) -> Tuple[
     if nbp_file.raw_extension != "jobs":
         if nbp_basic.use_anchor:
             # always have anchor as first round after imaging rounds
-            round_files = list(nbp_file.round) + [nbp_file.anchor]
+            round_files = nbp_file.round + [nbp_file.anchor]
         else:
-            round_files = list(nbp_file.round)
+            round_files = nbp_file.round
         if nbp_basic.use_preseq:
             round_files = round_files + [nbp_file.pre_seq]
         round_file = os.path.join(nbp_file.input_dir, round_files[r])

--- a/coppafish/utils/test/test_utils_base.py
+++ b/coppafish/utils/test/test_utils_base.py
@@ -4,13 +4,16 @@ import numpy as np
 from coppafish.utils import base
 
 
-def test_to_deep_tuple():
-    assert base.to_deep_tuple(list()) == tuple()
-    assert base.to_deep_tuple([[0, 2, 3], [1, 4], []]) == ((0, 2, 3), (1, 4), tuple())
-    assert base.to_deep_tuple(([0, 2, 3], [1, 4], [])) == ((0, 2, 3), (1, 4), tuple())
-    assert base.to_deep_tuple([[0, 2, [0]], [1, 4], []]) == ((0, 2, (0,)), (1, 4), tuple())
-    assert base.to_deep_tuple([[0, 2, (0,)], [1, 4], []]) == ((0, 2, (0,)), (1, 4), tuple())
-    assert base.to_deep_tuple([["fg" * 400], ["a" * 300]]) == (("fg" * 400,), ("a" * 300,))
+def test_to_deep_convert():
+    assert base.deep_convert(list()) == tuple()
+    assert base.deep_convert([[0, 2, 3], [1, 4], []]) == ((0, 2, 3), (1, 4), tuple())
+    assert base.deep_convert(([0, 2, 3], [1, 4], [])) == ((0, 2, 3), (1, 4), tuple())
+    assert base.deep_convert([[0, 2, [0]], [1, 4], []]) == ((0, 2, (0,)), (1, 4), tuple())
+    assert base.deep_convert([[0, 2, (0,)], [1, 4], []]) == ((0, 2, (0,)), (1, 4), tuple())
+    assert base.deep_convert([["fg" * 400], ["a" * 300]]) == (("fg" * 400,), ("a" * 300,))
+    assert base.deep_convert(((0, 1), (0,)), list) == [[0, 1], [0]]
+    assert base.deep_convert([], list) == []
+    assert base.deep_convert([], tuple) == tuple()
 
 
 def test_get_function_name():

--- a/coppafish/utils/test/test_utils_base.py
+++ b/coppafish/utils/test/test_utils_base.py
@@ -4,7 +4,7 @@ import numpy as np
 from coppafish.utils import base
 
 
-def test_to_deep_convert():
+def test_deep_convert():
     assert base.deep_convert(list()) == tuple()
     assert base.deep_convert([[0, 2, 3], [1, 4], []]) == ((0, 2, 3), (1, 4), tuple())
     assert base.deep_convert(([0, 2, 3], [1, 4], [])) == ((0, 2, 3), (1, 4), tuple())

--- a/coppafish/utils/tiles_io.py
+++ b/coppafish/utils/tiles_io.py
@@ -28,8 +28,6 @@ def get_compressor_and_chunks(
     # chunk size and compression level, it was found that zstd, chunk size of 1x2x2 and compression level 3 was
     # fast at the sum of full image reading + writing times while still compressing the files to ~70-80%.
     # Benchmarking done by Paul Shuker (paul.shuker@outlook.com), January 2024.
-    blosc.use_threads = True
-    blosc.set_nthreads(utils.system.get_core_count())
     if image_z_index is None:
         image_z_index = np.argmin(image_shape).item()
     if optimised_for == OptimisedFor.FULL_READ_AND_WRITE:
@@ -118,6 +116,8 @@ def _save_image(
     if image.dtype != IMAGE_SAVE_DTYPE:
         raise ValueError(f"Expected image dtype {IMAGE_SAVE_DTYPE}, got {image.dtype}")
 
+    blosc.use_threads = True
+    blosc.set_nthreads(utils.system.get_core_count())
     if optimised_for is None:
         optimised_for = OptimisedFor.FULL_READ_AND_WRITE
     if file_type.lower() == ".npy":


### PR DESCRIPTION
### Note:
This is not backwards compatible with previous run-throughs of the Omega branch. **You must delete the notebook and re-run.** However, you can keep extract/filter images in the tile directory.

### Changes:
- The notebook now returns lists instead of tuples (#311).
- OMP now saves results in a [zarr group](https://zarr.readthedocs.io/en/stable/tutorial.html#groups) within the notebook. Each tile is saved in a subgroup. This is less memory intensive and allows a large notebook with OMP to be loaded much faster. Also, the results are now compressed much better (#312).
- OMP default config is slightly better.
- The notebook has a more sophisticated config checker. Warnings are now issued about a modified config file only if that config section has already been used within the pipeline. This catches mistakes when the user thinks they have changed the pipeline by modifying the config file, but the config section has already been used.

### Checklist
- [x] I have updated the `changelog.txt`, if applicable.
- [x] I have bumped the software version in `_version.py`, if applicable.
- [x] I have checked that the unit tests passed.
- [x] I have checked that Minnie and/or RoboMinnie passed.
- [x] I have resolved merge conflicts.
